### PR TITLE
Handle setter-only classic class descriptors

### DIFF
--- a/tests/unit/computed-test.js
+++ b/tests/unit/computed-test.js
@@ -189,6 +189,41 @@ module('@computed', function() {
     );
   });
 
+  test('it works with classic classes with setter-only desc', function(assert) {
+    assert.expect(4);
+
+    let expectedName = 'rob jackson';
+
+    const Foo = EmberObject.extend({
+      first: 'rob',
+      last: 'jackson',
+
+      fullName: computed('first', 'last', {
+        set(key, name) {
+          assert.equal(name, expectedName, 'setter: name matches');
+
+          const [first, last] = name.split(' ');
+          setProperties(this, { first, last });
+
+          return name;
+        },
+      }),
+    });
+
+    let obj = Foo.create();
+
+    expectedName = 'yehuda katz';
+    set(obj, 'fullName', 'yehuda katz');
+
+    assert.equal(obj.first, 'yehuda', 'first name was updated');
+    assert.equal(obj.last, 'katz', 'last name was updated');
+    assert.strictEqual(
+      get(obj, 'fullName'),
+      expectedName,
+      'return value of setter is new value of property'
+    );
+  });
+
   test('dependent key changes invalidate the computed property', function(assert) {
     class Foo {
       first = 'rob';

--- a/vendor/ember-decorators-polyfill/index.js
+++ b/vendor/ember-decorators-polyfill/index.js
@@ -321,7 +321,7 @@ import {
         `Attempted to apply a computed property that already has a getter/setter to a ${key}, but it is a method or an accessor. If you passed @computed a function or getter/setter (e.g. \`@computed({ get() { ... } })\`), then it must be applied to a field`,
         !(
           desc &&
-          (typeof get === 'function' || typeof 'set' === 'function') &&
+          (typeof get === 'function' || typeof set === 'function') &&
           (typeof desc.get === 'function' || typeof desc.get === 'function')
         )
       );
@@ -336,7 +336,7 @@ import {
 
       assert(
         `Attempted to use @computed on ${key}, but it did not have a getter or a setter. You must either pass a get a function or getter/setter to @computed directly (e.g. \`@computed({ get() { ... } })\`) or apply @computed directly to a getter/setter`,
-        typeof get === 'function' || typeof 'set' === 'function'
+        typeof get === 'function' || typeof set === 'function'
       );
 
       if (desc !== undefined) {


### PR DESCRIPTION
Ran into this when one of the addons I was using had a setter-only classic computed. The number of times I've written `typeof 'myVar'` and then been baffled when it insisted on returning `'string'`... 😁 