### PR TITLE
Avoid crashing when Function.name is not configurable

### DIFF
--- a/vendor/ember-decorators-polyfill/index.js
+++ b/vendor/ember-decorators-polyfill/index.js
@@ -272,9 +272,14 @@ import {
     );
 
     if (DEBUG) {
-      Object.defineProperty(decorator, 'name', {
-        value: fnName,
-      });
+      let desc = Object.getOwnPropertyDescriptor(decorator, 'name');
+      // Pre ES2015 non standard implementation, "Function.name" is non configurable field
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name
+      if (desc.configurable) {
+        Object.defineProperty(decorator, 'name', {
+          value: fnName,
+        });
+      }
     }
 
     return decorator;


### PR DESCRIPTION
On older browsers `Function.name` is non configurable field.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name

Closes #7 