### PR TITLE
IE11 does not have Function.name defined

### DIFF
--- a/vendor/ember-decorators-polyfill/index.js
+++ b/vendor/ember-decorators-polyfill/index.js
@@ -275,7 +275,7 @@ import {
       let desc = Object.getOwnPropertyDescriptor(decorator, 'name');
       // Pre ES2015 non standard implementation, "Function.name" is non configurable field
       // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name
-      if (desc.configurable) {
+      if (desc && desc.configurable) {
         Object.defineProperty(decorator, 'name', {
           value: fnName,
         });


### PR DESCRIPTION
This means Object.getOwnPropertyDescriptor() will return undefined.

You can set the `Function.name` property on IE11 but I am not sure that it does what it does in other browsers. It's not changing actual method name.