### PR TITLE
[BUGFIX] Better Data Patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,7 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "after": [
-      "ember-source",
-      "ember-classic-decorator"
+      "ember-source"
     ]
   }
 }

--- a/vendor/ember-decorators-polyfill/data-fix.js
+++ b/vendor/ember-decorators-polyfill/data-fix.js
@@ -15,8 +15,6 @@
     );
   }
 
-  let mainRequire = require;
-
   function computedMacroWithOptionalParams(fn) {
     return (...maybeDesc) =>
       (isFieldDescriptor(maybeDesc)
@@ -28,16 +26,9 @@
     let DS;
 
     try {
-      DS = mainRequire('ember-data').default;
+      DS = window.requirejs('ember-data').default;
     } catch (e) {
-      return mainRequire(moduleName);
-    }
-
-    if (window.require !== patchDataDecorators) {
-      // Something else patched, most likely ember-classic-decorator
-      // and since we're about to do things we shouldn't, get the original
-      // require back
-      mainRequire = window.require;
+      return window.requirejs(moduleName);
     }
 
     let {
@@ -54,19 +45,19 @@
     DS.belongsTo = belongsTo;
     DS.hasMany = hasMany;
 
-    if (mainRequire.entries['@ember-data/model/index']) {
+    if (window.requirejs.entries['@ember-data/model/index']) {
       let newExports = Object.assign(
         {},
-        mainRequire.entries['@ember-data/model/index'].module.exports,
+        window.requirejs.entries['@ember-data/model/index'].module.exports,
         { attr, belongsTo, hasMany }
       );
 
-      mainRequire.entries['@ember-data/model/index'].module.exports = newExports;
+      window.requirejs.entries['@ember-data/model/index'].module.exports = newExports;
     }
 
-    window.require = require = mainRequire;
+    window.require = require = window.requirejs;
 
-    return mainRequire(moduleName);
+    return window.requirejs(moduleName);
   }
 })();
 


### PR DESCRIPTION
This version of the data patch doesn't rely on capturing the original
value. Instead it uses an alternate name that is defined by the AMD
loader internally, while replacing the main `require`.