### PR TITLE
[BUGFIX] Fix @classic decorator interop

### DIFF
--- a/vendor/ember-decorators-polyfill/data-fix.js
+++ b/vendor/ember-decorators-polyfill/data-fix.js
@@ -22,13 +22,14 @@
         : Function.apply.call(fn, undefined, maybeDesc))
   }
 
+  let originalRequire = window.require;
   window.require = require = function patchDataDecorators(moduleName) {
     let DS;
 
     try {
-      DS = window.requirejs('ember-data').default;
+      DS = originalRequire('ember-data').default;
     } catch (e) {
-      return window.requirejs(moduleName);
+      return originalRequire(moduleName);
     }
 
     let {


### PR DESCRIPTION
The last fix broke interop with the @classic decorator's patch, since
we need to call its require as well.